### PR TITLE
Make A-pose adjustment logic non-destructive; allow real-time edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "vite-plugin-glsl": "^1.1.2"
       },
       "devDependencies": {
+        "@types/three": "^0.179.0",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
         "eslint": "^8.56.0",
         "eslint-config-standard-with-typescript": "^43.0.0",
@@ -32,6 +33,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.18.20",
@@ -193,6 +201,13 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -215,6 +230,36 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.179.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.179.0.tgz",
+      "integrity": "sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.15.0",
@@ -410,6 +455,13 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.11.2",
@@ -1385,6 +1437,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2180,6 +2239,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build"
   },
   "devDependencies": {
+    "@types/three": "^0.179.0",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "eslint": "^8.56.0",
     "eslint-config-standard-with-typescript": "^43.0.0",

--- a/src/index.html
+++ b/src/index.html
@@ -270,21 +270,21 @@
                         </div>
 
                         <div style="display: flex; flex-direction: row; gap: 1rem; justify-content: flex-start; align-items: center;">
-                            <input type="number" id="extend-arm-input" name="arm-extend-input" value="3" min="-25" max="25" step="1">
+                            <input type="number" id="extend-arm-numeric-input" name="arm-extend-input" value="0" min="-50" max="50" step="1">
                             <span class="suffix-unit">%</span>
-                            <button id="extend-arm-button" class="secondary-button" >Open Arms</button>
-
-                                                <!-- checkbox option to show skeleton -->
-                            <div class="styled-checkbox icon-toggle">
-                                <input type="checkbox" id="show-skeleton-checkbox" name="show-skeleton" value="show" style="display:none;">
-                                <label for="show-skeleton-checkbox" title="Show skeleton" tabindex="0">
-                                    <img src="images/icons/bone-display.svg" width="30" height="30" alt="Show skeleton" />
-                                </label>
-                            </div>
+                            <label><input id="extend-arm-range-input" type="range" min="-50" max="50" value="0" /> Open Arms</label>
                         </div>
-
-                         <hr />
-                         
+                        
+                        <hr />
+                        
+                    </div>
+                    
+                    <!-- checkbox option to show skeleton -->
+                    <div class="styled-checkbox icon-toggle">
+                        <input type="checkbox" id="show-skeleton-checkbox" name="show-skeleton" value="show" style="display:none;">
+                        <label for="show-skeleton-checkbox" title="Show skeleton" tabindex="0">
+                            <img src="images/icons/bone-display.svg" width="30" height="30" alt="Show skeleton" />
+                        </label>
                     </div>
         
        

--- a/src/lib/UI.ts
+++ b/src/lib/UI.ts
@@ -54,8 +54,8 @@ export class UI {
   dom_total_time: HTMLElement | null = null
 
   dom_import_animations_button: HTMLButtonElement | null = null
-  dom_extend_arm_input: HTMLElement | null = null
-  dom_extend_arm_button: HTMLButtonElement | null = null
+  dom_extend_arm_range_input: HTMLInputElement | null = null
+  dom_extend_arm_numeric_input: HTMLInputElement | null = null
   dom_a_pose_correction_options: HTMLElement | null = null
   dom_export_button_hidden_link: HTMLElement | null = null
   dom_animation_count: HTMLElement | null = null
@@ -131,8 +131,8 @@ export class UI {
     this.dom_current_time = document.querySelector('#current-time')
     this.dom_total_time = document.querySelector('#total-time')
 
-    this.dom_extend_arm_input = document.querySelector('#extend-arm-input')
-    this.dom_extend_arm_button = document.querySelector('#extend-arm-button')
+    this.dom_extend_arm_range_input = document.querySelector('#extend-arm-range-input')
+    this.dom_extend_arm_numeric_input = document.querySelector('#extend-arm-numeric-input')
     this.dom_a_pose_correction_options = document.querySelector('#a-pose-correction-options')
 
     this.dom_build_version = document.querySelector('#build-version')

--- a/src/lib/Utilities.ts
+++ b/src/lib/Utilities.ts
@@ -290,10 +290,14 @@ export class Utility {
     return closest_bone_index
   }
 
+  static deep_clone_animation_clip (clip: AnimationClip): AnimationClip {
+    const tracks = clip.tracks.map((track: KeyframeTrack) => track.clone())
+    return new AnimationClip(clip.name, clip.duration, tracks)
+  }
+
   static deep_clone_animation_clips (animation_clips: AnimationClip[]): AnimationClip[] {
     return animation_clips.map((clip: AnimationClip) => {
-      const tracks = clip.tracks.map((track: KeyframeTrack) => track.clone())
-      return new AnimationClip(clip.name, clip.duration, tracks)
+      return Utility.deep_clone_animation_clip(clip)
     })
   }
 
@@ -314,5 +318,16 @@ export class Utility {
       animation_clip.tracks = rotation_tracks // update track data
       // console.log(animation_clip.tracks) // UNUSED DEBUG CODE
     })
+  }
+
+  static parse_input_number (value: string | undefined): number {
+    if (value === '' || value === undefined) {
+      return 0
+    }
+    const value_numeric = parseFloat(value);
+    if (typeof value_numeric !== 'number' || !isFinite(value_numeric)) {
+      return 0
+    }
+    return value_numeric;
   }
 }

--- a/src/lib/Utilities.ts
+++ b/src/lib/Utilities.ts
@@ -321,13 +321,17 @@ export class Utility {
   }
 
   static parse_input_number (value: string | undefined): number {
-    if (value === '' || value === undefined) {
+    if (value === undefined || value === null) {
       return 0
     }
-    const value_numeric = parseFloat(value);
+    value = value.trim()
+    if (value === '') {
+      return 0
+    }
+    const value_numeric = parseFloat(value)
     if (typeof value_numeric !== 'number' || !isFinite(value_numeric)) {
       return 0
     }
-    return value_numeric;
+    return value_numeric
   }
 }

--- a/src/lib/processes/StepAnimationsListing.ts
+++ b/src/lib/processes/StepAnimationsListing.ts
@@ -12,7 +12,7 @@ import { Utility } from '../Utilities.ts'
 import { ThemeManager } from '../ThemeManager.ts'
 import { AnimationSearch, AnimationWithState } from '../AnimationSearch.ts'
 
-export interface WarpedAnimationClip {
+export interface TransformedAnimationClipPair {
   /**
    * The original version of the animation clip, without any transformations
    * applied to it.
@@ -34,7 +34,7 @@ export class StepAnimationsListing extends EventTarget {
   private readonly theme_manager: ThemeManager
   private readonly ui: UI
   private readonly animation_player: AnimationPlayer
-  private animation_clips_loaded: WarpedAnimationClip[] = []
+  private animation_clips_loaded: TransformedAnimationClipPair[] = []
   private gltf_animation_loader: GLTFLoader = new GLTFLoader()
   private readonly fbx_animation_loader: FBXLoader = new FBXLoader()
 
@@ -213,7 +213,7 @@ export class StepAnimationsListing extends EventTarget {
 
   private onAllAnimationsLoaded (): void {
     // sort all animation names alphabetically
-    this.animation_clips_loaded.sort((a: WarpedAnimationClip, b: WarpedAnimationClip) => {
+    this.animation_clips_loaded.sort((a: TransformedAnimationClipPair, b: TransformedAnimationClipPair) => {
       if (a.display_animation_clip.name < b.display_animation_clip.name) { return -1 }
       if (a.display_animation_clip.name > b.display_animation_clip.name) { return 1 }
       return 0
@@ -269,7 +269,7 @@ export class StepAnimationsListing extends EventTarget {
    */
   private rebuild_warped_animations (): void {
     // Reset all of the warped clips to the corresponding original clip.
-    this.animation_clips_loaded.forEach((warped_clip: WarpedAnimationClip) => {
+    this.animation_clips_loaded.forEach((warped_clip: TransformedAnimationClipPair) => {
       warped_clip.display_animation_clip = Utility.deep_clone_animation_clip(warped_clip.original_animation_clip)
     })
     /// Apply the arm extension warp:
@@ -278,7 +278,7 @@ export class StepAnimationsListing extends EventTarget {
 
   private apply_arm_extension_warp (percentage: number): void {
     // loop through each animation clip to update the tracks
-    this.animation_clips_loaded.forEach((warped_clip: WarpedAnimationClip) => {
+    this.animation_clips_loaded.forEach((warped_clip: TransformedAnimationClipPair) => {
       warped_clip.display_animation_clip.tracks.forEach((track: KeyframeTrack) => {
         // if our name does not contain 'quaternion', we need to exit
         // since we are only modifying the quaternion tracks (e.g. L_Arm.quaternion )

--- a/src/lib/processes/StepAnimationsListing.ts
+++ b/src/lib/processes/StepAnimationsListing.ts
@@ -152,7 +152,7 @@ export class StepAnimationsListing extends EventTarget {
    * Returns a list of all of the currently-displayed animation clips. 
    */
   public animation_clips (): AnimationClip[] {
-    return this.animation_clips_loaded.map(clip => clip.original_animation_clip)
+    return this.animation_clips_loaded.map(clip => clip.display_animation_clip)
   }
 
   public load_and_apply_default_animation_to_skinned_mesh (final_skinned_meshes: SkinnedMesh[], skeleton_type: SkeletonType): void {


### PR DESCRIPTION
Updates the "A-Pose Correction" logic with a slider & numeric input that can be freely edited.

Instead of performing an incremental rotation of the arms in their current layout, it resets the animation to the original sample, and _then_ applies the current value for the transformation. This makes the UX better (since you can enter a custom target instead of adjusting up/down without knowing the baseline) and makes it easier to extend with multiple non-destructive transformations in the future (e.g. stride length, walking speed, ...)

(I also added `@types/three` as a dev dependency since otherwise the type info wasn't resolving for me)